### PR TITLE
Extend l10n documentation

### DIFF
--- a/_data/docs.yml
+++ b/_data/docs.yml
@@ -7,6 +7,7 @@
 - title: Using Flarum
   docs:
   - installation
+  - languages
   - troubleshooting
   - api
 
@@ -18,5 +19,13 @@
   - extend/api
   - extend/client
   - extend/themes
-  - extend/localization
+  - extend/internationalization
   - extend/distribution
+
+- title: Translating Flarum
+  docs:
+  - translate
+  - translate/packaging
+  - translate/localization
+  - translate/updating
+  - translate/distribution

--- a/_docs/extend/internationalization.md
+++ b/_docs/extend/internationalization.md
@@ -1,0 +1,6 @@
+---
+layout: docs
+title: Internationalization
+permalink: /docs/extend/internationalization/
+---
+This page is under construction.

--- a/_docs/extend/packaging.md
+++ b/_docs/extend/packaging.md
@@ -28,7 +28,7 @@ Once you've filled out all the details, the utility will create a new directory 
 * **flarum.json** Contains meta information about your extension (title, description, author, dependencies). More information a bit further down.
 * **js/** Where your extension's JavaScript lives. You'll learn more about this in [Extending the Client]({{ site.baseurl }}/docs/extend/client).
 * **less/** Where your extension's CSS styles live. You'll learn more about this in [Theming]({{ site.baseurl }}/docs/extend/theming).
-* **locale/** Where your extension's translations live. You'll learn more about this in [Localization]({{ site.baseurl }}/docs/extend/localization).
+* **locale/** Where your extension's translations live. You'll learn more about this in [Internationalization]({{ site.baseurl }}/docs/extend/internationalization).
 * **migrations/** Database migrations that are run when your extension is installed/upgraded/uninstalled. You'll learn more about these in [Extending the Domain]({{ site.baseurl }}/docs/extend/domain).
 * **src/** Where your extension's back-end source code lives, autoloaded by Composer using the PSR-4 standard.
 

--- a/_docs/languages.md
+++ b/_docs/languages.md
@@ -1,0 +1,6 @@
+---
+layout: docs
+title: Adding Languages
+permalink: /docs/languages/
+---
+This page is under construction.

--- a/_docs/translate/distribution.md
+++ b/_docs/translate/distribution.md
@@ -1,0 +1,6 @@
+---
+layout: docs
+title: Distribution
+permalink: /docs/translate/distribution/
+---
+This page is under construction.

--- a/_docs/translate/index.md
+++ b/_docs/translate/index.md
@@ -1,0 +1,6 @@
+---
+layout: docs
+title: Introduction
+permalink: /docs/translate/
+---
+This page is under construction.

--- a/_docs/translate/localization.md
+++ b/_docs/translate/localization.md
@@ -1,7 +1,7 @@
 ---
 layout: docs
 title: Localization
-permalink: /docs/extend/localization/
+permalink: /docs/translate/localization/
 ---
 ## Translations
 

--- a/_docs/translate/packaging.md
+++ b/_docs/translate/packaging.md
@@ -1,0 +1,6 @@
+---
+layout: docs
+title: Packaging
+permalink: /docs/translate/packaging/
+---
+This page is under construction.

--- a/_docs/translate/updating.md
+++ b/_docs/translate/updating.md
@@ -1,0 +1,6 @@
+---
+layout: docs
+title: Updating 
+permalink: /docs/translate/updating/
+---
+This page is under construction.


### PR DESCRIPTION
Refer to: http://discuss.flarum.org/d/1085/8
- Adds a page for langpack installation instructions.
- Renames the i18n page in the Extensions section.
- Modifies the packaging page in same to match.
- Adds a new section of l10n pages for translators.
