### PR TITLE
Fix nginx conf gzip_types

### DIFF
--- a/_docs/installation.md
+++ b/_docs/installation.md
@@ -67,11 +67,6 @@ Add the following lines to your server's configuration block:
     location /api { try_files $uri $uri/ /api.php?$query_string; }
     location /admin { try_files $uri $uri/ /admin.php?$query_string; }
 
-    location /flarum {
-        deny all;
-        return 404;
-    }
-
     location ~ .php$ {
         fastcgi_split_path_info ^(.+.php)(/.+)$;
         fastcgi_pass unix:/var/run/php5-fpm.sock;

--- a/_docs/installation.md
+++ b/_docs/installation.md
@@ -95,20 +95,19 @@ Add the following lines to your server's configuration block:
     gzip_vary on;
     gzip_comp_level 6;
     gzip_proxied any;
-    gzip_types application/atom+xml \
-               application/javascript \
-               application/json \
-               application/vnd.ms-fontobject \
-               application/x-font-ttf \
-               application/x-web-app-manifest+json \
-               application/xhtml+xml \
-               application/xml \
-               font/opentype \
-               image/svg+xml \
-               image/x-icon \
-               text/css \
-               text/html \
-               text/plain \
+    gzip_types application/atom+xml
+               application/javascript
+               application/json
+               application/vnd.ms-fontobject
+               application/x-font-ttf
+               application/x-web-app-manifest+json
+               application/xhtml+xml
+               application/xml
+               font/opentype
+               image/svg+xml
+               image/x-icon
+               text/css
+               text/plain
                text/xml;
     gzip_buffers 16 8k;
     gzip_disable "MSIE [1-6]\.(?!.*SV1)";


### PR DESCRIPTION
Hi,

This is what I did:
- Removal of \ ==> it generated warnings on Nginx 1.9.7
  
  > déc. 04 13:51:48 arch-server nginx[31473]: 2015/12/04 13:51:48 [warn] 31473#31473: duplicate MIME type "\
  > déc. 04 13:51:48 arch-server nginx[31473]: " in /etc/nginx/conf.d/acsemb.org.conf:100
- Removal of text/html duplicate ==> it generated warnings on Nginx 1.9.7
  
  > déc. 04 13:56:19 arch-server nginx[31701]: 2015/12/04 13:56:19 [warn] 31701#31701: duplicate MIME type "text/html" in /etc/nginx/conf.d/acsemb.org.conf:101

[According to this](http://nginx.org/en/docs/http/ngx_http_gzip_module.html#gzip_types), we don't need to add text/html.

> Responses with the “text/html” type are always compressed.
