### PR TITLE
Reorder fastcgi_params

### DIFF
--- a/_docs/installation.md
+++ b/_docs/installation.md
@@ -75,9 +75,9 @@ Add the following lines to your server's configuration block:
     location ~* \.php$ {
         fastcgi_split_path_info ^(.+.php)(/.+)$;
         fastcgi_pass unix:/var/run/php5-fpm.sock;
+        include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         fastcgi_index index.php;
-        include fastcgi_params;
     }
     
     location ~* \.html$ {


### PR DESCRIPTION
include fastcgi_params sets default parameters
fastcgi_param SCRIPT_FILENAME sets a specific parameter

Moved above so fastcgi_params doesn't override fastcgi_param
Solves php-fpm chroot issue where $document_root may no longer be relevant
