### PR TITLE
To avoid dependencies requirements

### DIFF
--- a/_docs/installation.md
+++ b/_docs/installation.md
@@ -29,6 +29,12 @@ There are a few things that you will need to have set up in order to run Flarum:
 * **PHP 5.5+** with the following extensions: mbstring, pdo_mysql, openssl, json, gd, dom, fileinfo
 * **MySQL 5.5+**
 * **SSH (command-line) access**
+* 
+
+```
+In order to avoid dependencies requirements.
+Add or Uncomment the line extension=php_fileinfo.dll on php.ini, and restart Apache.
+```
 
 <a name="installing-flarum"></a>
 


### PR DESCRIPTION
While installing in Windows system, composer throwed the bleow problem (see image), can be solved while updating the **php.ini** file.

Image URL :  http://rahulbohra.com/flarum/problem_1.png

Post URL : https://discuss.flarum.org/d/3220-problem-faced-while-installing-files-from-composer-ver-1-1-2-stable-channel
