### PR TITLE
Change GitHub repository link. Related to #44

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -12,7 +12,7 @@
       <a href="{{ site.baseurl }}/docs/installation">Download</a>
       <a href="{{ site.baseurl }}/docs">Documentation</a>
       <a href="http://discuss.flarum.org">Community</a>
-      <a href="https://github.com/flarum/flarum">GitHub</a>
+      <a href="https://github.com/flarum/core">GitHub</a>
     </nav>
   </div>
 </header>


### PR DESCRIPTION
I think the link points to the wrong GitHub repository, as I explained in the issue #44