### PR TITLE
Add tag list and order endpoints to API docs

### DIFF
--- a/_docs/api.md
+++ b/_docs/api.md
@@ -79,6 +79,8 @@ You can then pass the token in an Authorization header in subsequent requests:
 
 ## Tags
 
+* `GET /api/tags` - get all tags
 * `POST /api/tags` - create a new tag
 * `PATCH /api/tags/:id` - update a tag
 * `DELETE /api/tags/:id` - delete a tag
+* `POST /api/tags/order` - re-order tags


### PR DESCRIPTION
I noticed `GET /tags` and `POST /tags/order` were missing from the API docs, so this adds them.

Technically the `order` endpoint also manages which tags are primary or secondary by way of including/excluding them from the array. It could be worth mentioning this but I've kept it simple to better match the other descriptions, at least for now.