### PR TITLE
Removed manual SMTP configuration in Installation.md

### DIFF
--- a/_docs/installation.md
+++ b/_docs/installation.md
@@ -135,22 +135,6 @@ Add the following lines to your server's configuration block:
 
 If you're having a problem installing Flarum, check out the [Installation tag](http://discuss.flarum.org/t/installation) on the support forum. Someone might've had the same problem as you! If not, start a discussion and we'll do our best to help.
 
-<a name="configuring-smtp"></a>
-
-## Configuring SMTP
-
-There's currently no GUI to configure SMTP (see [#258](https://github.com/flarum/core/issues/258)). For now you can enter your details in manually in the `settings` database table using a tool like phpMyAdmin:
-
-```
-mail_driver: smtp
-mail_host: ...
-mail_from: ...
-mail_port: ...
-mail_username: ...
-mail_password: ...
-mail_encryption: ...
-```
-
 <a name="importing-data"></a>
 
 ## Importing Data


### PR DESCRIPTION
The section about manually configuring SMTP is redundant and I have removed it as you can now configure the email settings from the `admin` panel.