### PR TITLE
Add missing `curl` PHP extension in installation documentation.

### DIFF
--- a/_docs/installation.md
+++ b/_docs/installation.md
@@ -26,7 +26,7 @@ Before you install, please read our [Contributing]({{ site.baseurl }}/docs/contr
 There are a few things that you will need to have set up in order to run Flarum:
 
 * A web server: **Apache** (with mod_rewrite), **Nginx**, or **Lighttpd**
-* **PHP 5.6 up to 7.1 (not 7.2)** with the following extensions: mbstring, pdo_mysql, openssl, json, gd, dom, fileinfo
+* **PHP 5.6 up to 7.1 (not 7.2)** with the following extensions: curl, dom, fileinfo, gd, json, mbstring, openssl, pdo_mysql
 * **MySQL 5.5+**
 * **SSH (command-line) access**
 


### PR DESCRIPTION
Also list required extensions alphabetically, making it easier to check
whether all are installed.