### PR TITLE
Add php module tokenizer to requirements

### DIFF
--- a/_docs/installation.md
+++ b/_docs/installation.md
@@ -26,7 +26,7 @@ Before you install, please read our [Contributing]({{ site.baseurl }}/docs/contr
 There are a few things that you will need to have set up in order to run Flarum:
 
 * A web server: **Apache** (with mod_rewrite), **Nginx**, or **Lighttpd**
-* **PHP 5.6 up to 7.1 (not 7.2)** with the following extensions: mbstring, pdo_mysql, openssl, json, gd, dom, fileinfo, curl, tokenzier
+* **PHP 5.6 up to 7.1 (not 7.2)** with the following extensions: mbstring, pdo_mysql, openssl, json, gd, dom, fileinfo, tokenzier
 * **MySQL 5.5+**
 * **SSH (command-line) access**
 

--- a/_docs/installation.md
+++ b/_docs/installation.md
@@ -26,7 +26,7 @@ Before you install, please read our [Contributing]({{ site.baseurl }}/docs/contr
 There are a few things that you will need to have set up in order to run Flarum:
 
 * A web server: **Apache** (with mod_rewrite), **Nginx**, or **Lighttpd**
-* **PHP 5.6 up to 7.1 (not 7.2)** with the following extensions: mbstring, pdo_mysql, openssl, json, gd, dom, fileinfo, curl
+* **PHP 5.6 up to 7.1 (not 7.2)** with the following extensions: mbstring, pdo_mysql, openssl, json, gd, dom, fileinfo, curl, tokenzier
 * **MySQL 5.5+**
 * **SSH (command-line) access**
 

--- a/_docs/installation.md
+++ b/_docs/installation.md
@@ -26,7 +26,7 @@ Before you install, please read our [Contributing]({{ site.baseurl }}/docs/contr
 There are a few things that you will need to have set up in order to run Flarum:
 
 * A web server: **Apache** (with mod_rewrite), **Nginx**, or **Lighttpd**
-* **PHP 5.6 up to 7.1 (not 7.2)** with the following extensions: mbstring, pdo_mysql, openssl, json, gd, dom, fileinfo
+* **PHP 5.6 up to 7.1 (not 7.2)** with the following extensions: mbstring, pdo_mysql, openssl, json, gd, dom, fileinfo, curl
 * **MySQL 5.5+**
 * **SSH (command-line) access**
 


### PR DESCRIPTION
<s>Faced the following error on `composer create-project flarum/flarum . --stability=beta` on minimal Debian system:
```
    - flarum/flarum-ext-akismet v0.1.0-beta.6 requires tijsverkoyen/akismet ^1.1 -> satisfiable by tijsverkoyen/akismet[1.1.0, 1.1.1].
    - tijsverkoyen/akismet 1.1.1 requires ext-curl * -> the requested PHP extension curl is missing from your system.
```
</s>

**€: Removed due to: flarum/flarum@088fdb4
In this case https://github.com/flarum/docs/blob/master/user/ubuntu-server-install.md#install-dependancies need to be adjusted accordingly, removing php-curl install. Different PR**


Just found the second needed module `tokenizer`, without blank page + the following error is thrown:
```
(mod_fastcgi.c.2543) FastCGI-stderr: PHP message: PHP Fatal error:  Uncaught Error: Call to undefined function Illuminate\View\Compilers\token_get_all() in /var/www/flarum/vendor/illuminate/view/Compilers/BladeCompiler.php:142
```
________________________
#### Off topic:

I was a bid confused first where to create the PR. Would be nice to have the same docs on flarum.org and github flarum/docs. But I like the ones on flarum.org actually more, if it's about how to install flarum.
- https://flarum.org/docs/installation/ has a clean clear dependency list and config file for all usually supported webservers. How to install each dependency on which OS/version exactly should be out of scope of flarum docs, as trying it, quickly leads to obsolete/outdated install steps/package versions etc., if not really regularly someone maintains these.
- https://github.com/flarum/docs/blob/master/user/index.md lacks those clear dependency list. Yeah there are two "example" install guides, but those can only be seen as examples for very specific systems and setups. Ubuntu on a non-current version, PHP7.0, which is not the default any more on current Ubuntu, MySQL (Who uses MySQL vs. MariaDB? Often `mysql-server` is just a dummy package, providing MariaDB), Nginx chosen.
  - Users with some experience will anyway setup the system as they want it, choosing perhaps other webserver etc.
  - Users who are new to Linux, will surely stuck at some step, as it is not exactly correct for their specific system (any more).
- Having separate .md for specific OS, webserver, PHP version etc config instructions is good, but they should not distract from a clean flarum centred install guide, thus be placed within separate md pages.

But that's just my 2 cent about it 😃.
**€ Just saw btw. that merge/conversion is planned:**
`This repo will eventually be deprecated in favour of flarum/docs. But until a definitive conversion date is planned, you are welcome to contribute here.`